### PR TITLE
Pull Request #3 - First Unit Testing

### DIFF
--- a/src/tests/TestUtils/Helpers/AssertExtensions.cs
+++ b/src/tests/TestUtils/Helpers/AssertExtensions.cs
@@ -114,5 +114,22 @@ namespace TestUtils
             Action action = () => gitStatus.AssertEqual(other);
             action.ShouldThrow<AssertionException>();
         }
+
+        public static void AssertEqual(this GitRemote gitRemote, GitRemote other)
+        {
+            gitRemote.Name.Should().Be(other.Name);
+            gitRemote.Url.Should().Be(other.Url);
+            gitRemote.Login.Should().Be(other.Login);
+            gitRemote.User.Should().Be(other.User);
+            gitRemote.Token.Should().Be(other.Token);
+            gitRemote.Host.Should().Be(other.Host);
+            gitRemote.Function.Should().Be(other.Function);
+        }
+
+        public static void AssertNotEqual(this GitRemote gitRemote, GitRemote other)
+        {
+            Action action = () => gitRemote.AssertEqual(other);
+            action.ShouldThrow<AssertionException>();
+        }
     }
 }

--- a/src/tests/UnitTests/Git/GitRemoteTests.cs
+++ b/src/tests/UnitTests/Git/GitRemoteTests.cs
@@ -18,5 +18,23 @@ namespace UnitTests
 
             gitRemote.AssertEqual(gitRemote);
         }
+
+        [Test]
+        public void ShouldNotEqualDifferentRemote()
+        {
+            var gitRemote = new GitRemote("Name",
+                "Host", "URL",
+                GitRemoteFunction.Unknown,
+                "User",
+                "Login", "Token");
+
+            var gitRemote2 = new GitRemote("`Name",
+               "`Host", "`URL",
+               GitRemoteFunction.Push,
+               "`User",
+               "`Login", "`Token");
+
+            gitRemote.AssertNotEqual(gitRemote2);
+        }
     }
 }

--- a/src/tests/UnitTests/Git/GitRemoteTests.cs
+++ b/src/tests/UnitTests/Git/GitRemoteTests.cs
@@ -1,0 +1,22 @@
+﻿using TestUtils;
+using NUnit.Framework;
+using GitHub.Unity;
+
+namespace UnitTests
+{
+    [TestFixture]
+    public class GitRemoteTests
+    {
+        [Test]
+        public void ShouldEqualSelf()
+        {
+             var gitRemote = new GitRemote("Name",
+                "Host", "URL",
+                GitRemoteFunction.Unknown,
+                "User",
+                "Login", "Token");
+
+            gitRemote.AssertEqual(gitRemote);
+        }
+    }
+}

--- a/src/tests/UnitTests/UnitTests.csproj
+++ b/src/tests/UnitTests/UnitTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="IO\LinuxDiskUsageOutputProcessorTests.cs" />
     <Compile Include="IO\LockOutputProcessorTests.cs" />
     <Compile Include="IO\CountObjectProcessorTests.cs" />
+    <Compile Include="Git\GitRemoteTests.cs" />
     <Compile Include="IO\VersionOutputProcessorTests.cs" />
     <Compile Include="IO\RemoteListOutputProcessorTests.cs" />
     <Compile Include="IO\BaseOutputProcessorTests.cs" />


### PR DESCRIPTION
Added GitRemoteTests.cs to perform unit testing on GitRemote.cs. Wrote two simple unit tests checking the functionality of GitRemote's values/pointers and wrote AssertEqual/AssertNotEqual functions in AssertExtensions.cs so that assertions can be used in current and future testing of GitRemote.